### PR TITLE
[FEAT] #104 전문가 계정 excel export 문항 확장 및 가독성 향상

### DIFF
--- a/WebContent/sdqResultAll.jsp
+++ b/WebContent/sdqResultAll.jsp
@@ -306,8 +306,8 @@ function showTarget(targetType) {
     const allBlocks = document.querySelectorAll('.result-block');
 
     // 안내문 토글
-    document.querySelectorAll(".report-intro").forEach(el => {
-        el.style.display = (el.getAttribute("data-target") === targetType) ? "block" : "none";
+    document.querySelectorAll(".report-intro").forEach(function(el) => {
+    	function(el).style.display = (el.getAttribute("data-target") === targetType) ? "block" : "none";
     });
 
     // 결과 블록 토글

--- a/src/controller/sdq/GetSdqResultAll.java
+++ b/src/controller/sdq/GetSdqResultAll.java
@@ -67,9 +67,10 @@ public class GetSdqResultAll extends HttpServlet {
  			out.flush();
  		}else {
  			SdqTestLog selectedSdqTestLog = null;
+ 			String testLogId = request.getParameter("sdqTestLogId");
  			
  			//선택한 테스트 로그 정보 가져오기
- 			if(request.getParameter("sdqTestLogId")==null||request.getParameter("sdqTestLogId").equals("0")) {//사용자가 가장 최근에 수행한 검사 기록 가져오기
+ 			if(testLogId ==null||testLogId.equals("0")) {//사용자가 가장 최근에 수행한 검사 기록 가져오기
  				Comparator<SdqTestLog> comparatorById = Comparator.comparingInt(SdqTestLog::getSdqTestLogId);
  				selectedSdqTestLog = sdqTestLogList.stream().max(comparatorById).orElseThrow(NoSuchElementException::new);
  			}else {

--- a/src/controller/user/ExportChildListResultExcel.java
+++ b/src/controller/user/ExportChildListResultExcel.java
@@ -42,7 +42,7 @@ public class ExportChildListResultExcel extends HttpServlet {
 		Connection conn= (Connection) sc.getAttribute("DBconnection");
 
 		
-		String exportType = request.getParameter("exportType"); // child, test
+		String exportType = request.getParameter("exportType"); // 아동별, 검사별
 		String[] childIdStrList = request.getParameterValues("childId");
 		String[] categoryList = request.getParameterValues("category");
 		
@@ -59,7 +59,6 @@ public class ExportChildListResultExcel extends HttpServlet {
 				out.println("<script>alert('결과 파일 추출에 실패했습니다. 관리자에게 문의하세요.'); hitory.go(-1);</script>");
 				out.flush();
 			}
-			
 			String[] files = directory.list();
 			
 			if(files != null && files.length > 0) {

--- a/src/model/dto/export/SskExcel.java
+++ b/src/model/dto/export/SskExcel.java
@@ -16,7 +16,7 @@ public class SskExcel {
     Sheet sheet;
     int rowIndex = 0;
 
-    CellStyle defaultCellStyle, headerCellStyle, bodyCellStyle;
+    CellStyle defaultCellStyle, headerCellStyle, bodyCellStyle, greyCellStyle, typeCellStyle;
     
     /*Get FileName*/
     public String getFileName(){
@@ -71,5 +71,39 @@ public class SskExcel {
         bodyCellStyle.setBorderBottom(BorderStyle.THIN);
         bodyCellStyle.setBorderLeft(BorderStyle.THIN);
         bodyCellStyle.setBorderRight(BorderStyle.THIN);
+    }
+    
+    public void setGreyCellStyle(){
+    	greyCellStyle = wb.createCellStyle();
+
+        // 정렬
+    	greyCellStyle.setAlignment(HorizontalAlignment.CENTER);
+    	greyCellStyle.setVerticalAlignment(VerticalAlignment.CENTER);
+
+        // 테두리
+    	greyCellStyle.setBorderTop(BorderStyle.THIN);
+    	greyCellStyle.setBorderBottom(BorderStyle.THIN);
+    	greyCellStyle.setBorderLeft(BorderStyle.THIN);
+    	greyCellStyle.setBorderRight(BorderStyle.THIN);
+ 
+        greyCellStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.getIndex());
+        greyCellStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+    }
+    
+    public void setTypeCellStyle(){
+    	typeCellStyle = wb.createCellStyle();
+
+        // 정렬
+    	typeCellStyle.setAlignment(HorizontalAlignment.CENTER);
+    	typeCellStyle.setVerticalAlignment(VerticalAlignment.CENTER);
+
+        // 테두리
+    	typeCellStyle.setBorderTop(BorderStyle.THIN);
+    	typeCellStyle.setBorderBottom(BorderStyle.THIN);
+    	typeCellStyle.setBorderLeft(BorderStyle.THIN);
+    	typeCellStyle.setBorderRight(BorderStyle.THIN);
+ 
+    	typeCellStyle.setFillForegroundColor(IndexedColors.LIGHT_TURQUOISE.getIndex());
+    	typeCellStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
     }
 }

--- a/src/model/dto/export/SskExcelByTest.java
+++ b/src/model/dto/export/SskExcelByTest.java
@@ -8,6 +8,7 @@ import static model.dto.export.column.SdqColumnInfoOfTest.*;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.List;
 
 import model.dto.LangReply;
 import org.apache.poi.ss.usermodel.Cell;
@@ -41,7 +42,7 @@ public class SskExcelByTest extends SskExcel{
     }
 
     /*Lang Data Export*/
-    public void addLangData(ArrayList<LangExcelDTO> langExcelDTOS){
+    public void addLangData(List<LangExcelDTO> langExcelDTOS){
     	this.fileName = "언어_발달_검사_결과_" + new Date(System.currentTimeMillis()) +".xlsx";
 
         Row titleRow = sheet.createRow(rowIndex);
@@ -84,7 +85,7 @@ public class SskExcelByTest extends SskExcel{
     }
 
     /*Sdq Data Export*/
-    public void addSdqData(ArrayList<SdqExcelDTO> sdqExcelDTOS){
+    public void addSdqData(List<SdqExcelDTO> sdqExcelDTOS){
     	this.fileName = "SDQ_정서_행동_발달_검사_결과_" + new Date(System.currentTimeMillis()) +".xlsx";
 
         Row titleRow = sheet.createRow(rowIndex);
@@ -135,7 +136,7 @@ public class SskExcelByTest extends SskExcel{
             createCellWithStyleInt(bodyRow, SDQ_ANSWER24.getColumnIndex(), sdqExcelDTO.getReplyList().get(23), bodyCellStyle);
             createCellWithStyleInt(bodyRow, SDQ_ANSWER25.getColumnIndex(), sdqExcelDTO.getReplyList().get(24), bodyCellStyle);
 
-            ArrayList<SdqResultOfType> scoreList = sdqExcelDTO.getScoreList();
+            List<SdqResultOfType> scoreList = sdqExcelDTO.getScoreList();
 
             /*match sdq result and type column*/
             for (SdqResultOfType sdqResultOfType : scoreList) {
@@ -152,7 +153,7 @@ public class SskExcelByTest extends SskExcel{
     }
 
     /*Esm Data Export*/
-    public void addEsmData(ArrayList<EsmExcelDTO> esmExcelDTOS){
+    public void addEsmData(List<EsmExcelDTO> esmExcelDTOS){
     	this.fileName = "ESM_정서_반복_기록_" + new Date(System.currentTimeMillis()) +".xlsx";
         
         Row titleRow = sheet.createRow(rowIndex);
@@ -187,7 +188,7 @@ public class SskExcelByTest extends SskExcel{
             createCellWithStyleInt(bodyRow, ESM_ANSWER9.getColumnIndex(), esmExcelDTO.getReplyList().get(8), bodyCellStyle);
             createCellWithStyleInt(bodyRow, ESM_ANSWER10.getColumnIndex(), esmExcelDTO.getReplyList().get(9), bodyCellStyle);
 
-            ArrayList<EsmResultOfType> scoreList = esmExcelDTO.getScoreList();
+            List<EsmResultOfType> scoreList = esmExcelDTO.getScoreList();
 
             /*match sdq result and type column*/
             for (EsmResultOfType esmResultOfType : scoreList) {
@@ -201,7 +202,7 @@ public class SskExcelByTest extends SskExcel{
     }
 
     /*ESM Record Data Export*/
-    public void addEsmRecordData(ArrayList<EsmRecordExcelDTO> esmRecordExcelDTOS){
+    public void addEsmRecordData(List<EsmRecordExcelDTO> esmRecordExcelDTOS){
     	this.fileName = "ESM_정서_다이어리_" + new Date(System.currentTimeMillis()) +".xlsx";
         
         Row titleRow = sheet.createRow(rowIndex);

--- a/src/model/dto/export/SskExcelByUser.java
+++ b/src/model/dto/export/SskExcelByUser.java
@@ -25,6 +25,7 @@ import static model.dto.export.column.UserColumnInfo.*;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.List;
 
 public class SskExcelByUser extends SskExcel{
 
@@ -36,6 +37,8 @@ public class SskExcelByUser extends SskExcel{
         setDefaultCellStyle();
         setHeaderCellStyle();
         setBodyCellStyle();
+        setGreyCellStyle();
+        setTypeCellStyle();
     }
 
     /*User data export*/
@@ -94,19 +97,13 @@ public class SskExcelByUser extends SskExcel{
             createCellWithStyle(bodyRow, LANG_AGE_GROUP.getColumnIndex(), langExcelDTO.getAgeGroupStr(), bodyCellStyle);
             sheet.autoSizeColumn(LANG_DATE.getColumnIndex());
             sheet.autoSizeColumn(LANG_AGE_GROUP.getColumnIndex());
-            System.out.println("langExcelDTO.getReplyList() size : " + langExcelDTO.getReplyList().size());
-            createCellWithStyle(bodyRow, LANG_ANSWER1.getColumnIndex(), langExcelDTO.getReplyList().get(0), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER2.getColumnIndex(), langExcelDTO.getReplyList().get(1), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER3.getColumnIndex(), langExcelDTO.getReplyList().get(2), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER4.getColumnIndex(), langExcelDTO.getReplyList().get(3), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER5.getColumnIndex(), langExcelDTO.getReplyList().get(4), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER6.getColumnIndex(), langExcelDTO.getReplyList().get(5), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER7.getColumnIndex(), langExcelDTO.getReplyList().get(6), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER8.getColumnIndex(), langExcelDTO.getReplyList().get(7), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER9.getColumnIndex(), langExcelDTO.getReplyList().get(8), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER10.getColumnIndex(), langExcelDTO.getReplyList().get(9), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER11.getColumnIndex(), langExcelDTO.getReplyList().get(10), bodyCellStyle);
-            createCellWithStyle(bodyRow, LANG_ANSWER12.getColumnIndex(), langExcelDTO.getReplyList().get(11), bodyCellStyle);
+            System.out.println("langExcelDTO.getReplyList() size : " + langExcelDTO.getReplyList().size());            
+            // 답변 12개 루프 처리
+            for (int i = 0; i < 12; i++) {
+                String reply = langExcelDTO.getReplyList().get(i);
+                CellStyle style = reply.equals("-") ? greyCellStyle : bodyCellStyle;
+                createCellWithStyle(bodyRow, LANG_ANSWER1.getColumnIndex() + i, reply, style);
+            }
         }
     }
 
@@ -162,14 +159,14 @@ public class SskExcelByUser extends SskExcel{
             createCellWithStyleInt(bodyRow, SDQ_ANSWER24.getColumnIndex(), sdqExcelDTO.getReplyList().get(23), bodyCellStyle);
             createCellWithStyleInt(bodyRow, SDQ_ANSWER25.getColumnIndex(), sdqExcelDTO.getReplyList().get(24), bodyCellStyle);
 
-            ArrayList<SdqResultOfType> scoreList = sdqExcelDTO.getScoreList();
+            List<SdqResultOfType> scoreList = sdqExcelDTO.getScoreList();
 
             /*match sdq result and type column*/
             for (SdqResultOfType sdqResultOfType : scoreList) {
                 String typeName = sdqResultOfType.getSdqType();
                 int columnIndex = SdqColumnInfoOfUser.findByColumnText(typeName).getColumnIndex();
 
-                createCellWithStyleInt(bodyRow, columnIndex, sdqResultOfType.getResult(), bodyCellStyle);
+                createCellWithStyleInt(bodyRow, columnIndex, sdqResultOfType.getResult(), typeCellStyle);
                 sheet.autoSizeColumn(columnIndex);
 
             }
@@ -214,14 +211,14 @@ public class SskExcelByUser extends SskExcel{
             createCellWithStyleInt(bodyRow, ESM_ANSWER9.getColumnIndex(), esmExcelDTO.getReplyList().get(8), bodyCellStyle);
             createCellWithStyleInt(bodyRow, ESM_ANSWER10.getColumnIndex(), esmExcelDTO.getReplyList().get(9), bodyCellStyle);
 
-            ArrayList<EsmResultOfType> scoreList = esmExcelDTO.getScoreList();
+            List<EsmResultOfType> scoreList = esmExcelDTO.getScoreList();
 
             /*match sdq result and type column*/
             for (EsmResultOfType esmResultOfType : scoreList) {
                 String typeName = esmResultOfType.getEsmType();
                 int columnIndex = EsmColumnInfoOfUser.findColumnByEsmType(typeName).getColumnIndex();
 
-                createCellWithStyleInt(bodyRow, columnIndex, esmResultOfType.getResult(), bodyCellStyle);
+                createCellWithStyleInt(bodyRow, columnIndex, esmResultOfType.getResult(), typeCellStyle);
             }
 
         }

--- a/src/model/dto/export/data/LangExcelDTO.java
+++ b/src/model/dto/export/data/LangExcelDTO.java
@@ -4,6 +4,7 @@ import model.dto.AgeGroup;
 
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.List;
 
 public class LangExcelDTO {
     private int userId;
@@ -13,7 +14,7 @@ public class LangExcelDTO {
     private String dateStr;
 
     private String ageGroupStr;
-    private ArrayList<String> replyList;
+    private List<String> replyList;
 
     public int getUserId() {
         return userId;
@@ -56,11 +57,11 @@ public class LangExcelDTO {
     }
 
 
-    public ArrayList<String> getReplyList() {
+    public List<String> getReplyList() {
         return replyList;
     }
 
-    public void setReplyList(ArrayList<String> replyList) {
+    public void setReplyList(List<String> replyList) {
         this.replyList = replyList;
     }
 

--- a/src/model/sevice/ExportChildResultExcelService.java
+++ b/src/model/sevice/ExportChildResultExcelService.java
@@ -57,7 +57,7 @@ public class ExportChildResultExcelService {
             langData.setDateStr(langTestLog.getLangTestDate());
             langData.setAgeGroupStr(LangReplyDAO.getLangAgeGroupIdByLogId(con,langTestLog.getLangTestLogId()));
 
-            List<String> langTypeList = Arrays.asList("구문", "문해", "문해1", "문해2", "문해3", "의미", "의미1", "의미2", "조음", "화용", "화용1", "화용2");
+            List<String> langTypeList = new ArrayList<>(Arrays.asList("구문", "문해", "문해1", "문해2", "문해3", "의미", "의미1", "의미2", "조음", "화용", "화용1", "화용2"));
             ArrayList<String> langReplyStrList = new ArrayList<String>();
             
             List<LangReply> langReplyList = LangReplyDAO.getLangReplyListByLangTestLogId(con,langTestLog.getLangTestLogId());
@@ -75,6 +75,7 @@ public class ExportChildResultExcelService {
                 }
             });
             int e = 0;
+            
             for(int j=0;j < 12 ;j++){
             	if (e < langReplyList.size()) {
 	                LangQuestion q1 = LangQuestionDAO.getLangQuestionById(con, langReplyList.get(e).getLangQuestionId());
@@ -89,9 +90,9 @@ public class ExportChildResultExcelService {
             	}
 	            langTypeList.remove(0);
             }
-            
             langData.setReplyList(langReplyStrList);
             langDataList.add(langData);
+            
         }
         return langDataList;
     }
@@ -100,7 +101,7 @@ public class ExportChildResultExcelService {
     public static ArrayList<SdqExcelDTO> getSdqDataListOfUser(Connection con, int childId, String childName){
         ArrayList<SdqExcelDTO> sdqDataList = new ArrayList<SdqExcelDTO>();
 
-        ArrayList<SdqTestLog> sdqTestLogList = SdqTestLogDAO.getSdqTestLogAllByUserId(con, childId);//아동의 모든 SDQ 기록 가져오기
+        List<SdqTestLog> sdqTestLogList = SdqTestLogDAO.getSdqTestLogAllByUserId(con, childId);//아동의 모든 SDQ 기록 가져오기
         for(int i=0;i< sdqTestLogList.size();i++){
             SdqTestLog sdqTestLog = sdqTestLogList.get(i);
 
@@ -173,10 +174,10 @@ public class ExportChildResultExcelService {
 	 *  - getSskExcelByTest : 검사별 검사 결과 excel을 만들어서 반환
 	 */
     /*해당하는 아동 리스트의 모든 언어 검사 결과 */
-    public static ArrayList<LangExcelDTO> getLangDataList(Connection con, String[] childIdStrList){
-    	ArrayList<LangExcelDTO> langDataList = new ArrayList<LangExcelDTO>();
+    public static List<LangExcelDTO> getLangDataList(Connection con, String[] childIdStrList){
+    	List<LangExcelDTO> langDataList = new ArrayList<LangExcelDTO>();
 
-        ArrayList<LangTestLog> langTestLogList = LangTestLogDAO.getLangTestLogListOfChildList(con, childIdStrList);
+        List<LangTestLog> langTestLogList = LangTestLogDAO.getLangTestLogListOfChildList(con, childIdStrList);
         for(int i=0;i<langTestLogList.size();i++){
             LangTestLog langTestLog = langTestLogList.get(i);
             User user = UserDAO.getUserById(con, langTestLog.getUserId());
@@ -189,8 +190,8 @@ public class ExportChildResultExcelService {
             langData.setDateStr(langTestLog.getLangTestDate());
             langData.setAgeGroupStr(LangReplyDAO.getLangAgeGroupIdByLogId(con,langTestLog.getLangTestLogId()));
            
-            ArrayList<LangReply> langReplyList = LangReplyDAO.getLangReplyListByLangTestLogId(con,langTestLog.getLangTestLogId());
-            ArrayList<String> langReplyStrList = new ArrayList<String>();
+            List<LangReply> langReplyList = LangReplyDAO.getLangReplyListByLangTestLogId(con,langTestLog.getLangTestLogId());
+            List<String> langReplyStrList = new ArrayList<String>();
             List<String> langTypeList = Arrays.asList("구문", "문해", "문해1", "문해2", "문해3", "의미", "의미1", "의미2", "조음", "화용", "화용1", "화용2");
 
 
@@ -254,10 +255,10 @@ public class ExportChildResultExcelService {
     }
     
     /*해당하는 아동 리스트의 모든 정서 반복 기록*/
-    public static ArrayList<EsmExcelDTO> getEsmDataList(Connection con, String[] childIdStrList){
-    	ArrayList<EsmExcelDTO> esmDataList = new ArrayList<EsmExcelDTO>();
+    public static List<EsmExcelDTO> getEsmDataList(Connection con, String[] childIdStrList){
+    	List<EsmExcelDTO> esmDataList = new ArrayList<EsmExcelDTO>();
 
-        ArrayList<EsmTestLog> esmTestLogList = EsmTestLogDAO.getEsmTestLogListOfChildList(con, childIdStrList);
+        List<EsmTestLog> esmTestLogList = EsmTestLogDAO.getEsmTestLogListOfChildList(con, childIdStrList);
         for(int i=0;i< esmTestLogList.size();i++){
             EsmTestLog esmTestLog = esmTestLogList.get(i);
             User user = UserDAO.getUserById(con, esmTestLog.getUserId());
@@ -281,7 +282,7 @@ public class ExportChildResultExcelService {
     public static ArrayList<EsmRecordExcelDTO> getEsmRecordDataList(Connection con, String[] childIdStrList){
     	ArrayList<EsmRecordExcelDTO> esmRecordDataList = new ArrayList<EsmRecordExcelDTO>();
 
-        ArrayList<EsmRecord> esmRecordList = EsmRecordDAO.getEsmRecordListOfChildList(con, childIdStrList);
+        List<EsmRecord> esmRecordList = EsmRecordDAO.getEsmRecordListOfChildList(con, childIdStrList);
         for(int i=0;i<esmRecordList.size();i++){
             EsmRecordExcelDTO esmRecordData = new EsmRecordExcelDTO();
             EsmRecord esmRecord = esmRecordList.get(i);
@@ -305,7 +306,7 @@ public class ExportChildResultExcelService {
     public static SskExcelByUser getSskExcelByChild(Connection con, int childId, boolean lang, boolean sdq, boolean esm, boolean esmRecord){
         SskExcelByUser sskExcelByUser = new SskExcelByUser();
 
-        UserExcelDTO userExcelDTO = getChildData(con, childId);
+        UserExcelDTO userExcelDTO = getChildData(con, childId); // 아동 기본 정보 (id, name, logInid, email, Birth, Gender)
         sskExcelByUser.addUserData(userExcelDTO);
 
         if(lang==true){
@@ -333,19 +334,19 @@ public class ExportChildResultExcelService {
     	SskExcelByTest sskExcelByTest = new SskExcelByTest();
     	switch(category) {
 			case "lang":
-				ArrayList<LangExcelDTO> langExcelDTOS = getLangDataList(con, childIdStrList);
+				List<LangExcelDTO> langExcelDTOS = getLangDataList(con, childIdStrList);
 	            sskExcelByTest.addLangData(langExcelDTOS);
 				break;
 			case "sdq":
-				ArrayList<SdqExcelDTO> sdqExcelDTOS = getSdqDataList(con, childIdStrList);
+				List<SdqExcelDTO> sdqExcelDTOS = getSdqDataList(con, childIdStrList);
 				sskExcelByTest.addSdqData(sdqExcelDTOS);
 				break;
 			case "esm":
-				ArrayList<EsmExcelDTO> esmExcelDTOS = getEsmDataList(con, childIdStrList);
+				List<EsmExcelDTO> esmExcelDTOS = getEsmDataList(con, childIdStrList);
 				sskExcelByTest.addEsmData(esmExcelDTOS);
 				break;
 			case "esmRecord":
-				ArrayList<EsmRecordExcelDTO> esmRecordExcelDTOS = getEsmRecordDataList(con, childIdStrList);
+				List<EsmRecordExcelDTO> esmRecordExcelDTOS = getEsmRecordDataList(con, childIdStrList);
 				sskExcelByTest.addEsmRecordData(esmRecordExcelDTOS);
 				break;
 		}


### PR DESCRIPTION
[문항 확장]
- 언어발달평가 타입 7 -> 12
- 정서/행동 발달 검사 10문항 -> 25문항
[가독성 향상]
- 언어발달평가 연령별 빈 항목 '-' 셀 어둡게 변경
- 정서/행동 발달 & 정서 반복 기록, 타입별 점수 셀 색상 추가